### PR TITLE
Check error descriptions during untyped tests

### DIFF
--- a/apps/sel4test-tests/src/tests/inc_untyped.c
+++ b/apps/sel4test-tests/src/tests/inc_untyped.c
@@ -28,6 +28,17 @@ test_retype(env_t env)
     error = vka_alloc_untyped(&env->vka, seL4_TCBBits + 3, &untyped);
     test_assert(error == 0);
 
+    /* Try to insert 0. */
+    error = seL4_Untyped_Retype(untyped.cptr,
+                                seL4_TCBObject, 0,
+                                env->cspace_root, cnode.cptr, seL4_WordBits,
+                                1, 0);
+    test_assert(error == seL4_RangeError);
+
+    /* Check we got useful min/max error codes. */
+    test_eq(seL4_GetMR(0), 1ul);
+    test_eq(seL4_GetMR(1), 256ul);
+
     /* Try to drop two caps in, at the end of the cnode, overrunning it. */
     error = seL4_Untyped_Retype(untyped.cptr,
                                 seL4_TCBObject, 0,


### PR DESCRIPTION
- This test will pass on current master, which always uses buffered
  machine registers for syscalls

- It will fail if syscall_stub_gen.py is run without --buffer, as
  the error descriptions are lost on the way through [1]

- It will pass once more when seL4/seL4#45 lands :-)

[1] http://sel4.systems/pipermail/devel/2016-October/001079.html