### PR TITLE
Polluted environment when running make compile-all

### DIFF
--- a/tools/compile-all.sh
+++ b/tools/compile-all.sh
@@ -8,7 +8,7 @@ do
     make clean > /dev/null
     make $config > /dev/null
     make silentoldconfig > /dev/null
-    make kernel_elf > /dev/null
+    env -i PATH="$PATH" make kernel_elf > /dev/null
     if [ $? -eq 0 ]
     then
         echo "pass"


### PR DESCRIPTION
The environment variables from different runs affect compilation in the
compile-all target, which causes the compilation of some defconfigs to
fail. Fix by compiling each kernel_elf target in a clean environment.