### PR TITLE
Add compile-all-clang target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ endif
 compile-all:
 	${PWD}/projects/sel4test/tools/compile-all.sh
 
+# test that all configs compile with clang
+compile-all-clang:
+	CLANG=1 ${PWD}/projects/sel4test/tools/compile-all.sh
+
 # objdump the kernel image
 objdump-kernel:
 	${CONFIG_CROSS_COMPILER_PREFIX}objdump -${OBJFLAGS} stage/${ARCH}/${PLAT}/kernel.elf

--- a/tools/compile-all.sh
+++ b/tools/compile-all.sh
@@ -17,6 +17,11 @@ do
     echo $config
     make clean > /dev/null
     make $config > /dev/null
+    if [ "$CLANG" = "1" ]
+    then
+        sed -i 's/.*CONFIG_KERNEL_COMPILER.*//g' .config
+        sed -i '$ a\CONFIG_KERNEL_COMPILER="clang"' .config
+    fi
     make silentoldconfig > /dev/null
     env -i PATH="$PATH" make kernel_elf > /dev/null
     if [ $? -eq 0 ]


### PR DESCRIPTION
The compile-all-clang target runs the compile-all.sh script with clang
as the compiler.

I am using this target to test my clang makefile porting efforts. I guess I will have a pull request soon with the changes needed to compile the kernel for most configs.