### PR TITLE
riscv: update sel4test for functionality on rocket-chip.

### DIFF
--- a/apps/sel4test-tests/arch/riscv/arch_frame_type.h
+++ b/apps/sel4test-tests/arch/riscv/arch_frame_type.h
@@ -18,10 +18,10 @@
 
 /* This list must be ordered by size - highest first */
 static const frame_type_t frame_types[] = {
-#if __riscv_xlen == 64
+    /* Rocket-Chip for zedboard only has 256MiB of RAM, so we can't allocate a 1GiB page */
+#if __riscv_xlen == 64 && !defined(CONFIG_BUILD_ROCKET_CHIP_ZEDBOARD)
     { seL4_RISCV_Giga_Page, 0, seL4_HugePageBits, },
 #endif
     { seL4_RISCV_Mega_Page, 0, seL4_LargePageBits, },
     { seL4_RISCV_4K_Page, BIT(seL4_LargePageBits), seL4_PageBits, },
 };
-

--- a/apps/sel4test-tests/src/tests/faults.c
+++ b/apps/sel4test-tests/src/tests/faults.c
@@ -48,8 +48,12 @@ enum {
 #define BAD_VADDR 0xf123456C
 #endif
 #elif CONFIG_WORD_SIZE == 64
+#ifdef CONFIG_ARCH_RISCV64
+#define BAD_VADDR 0x3CBA987650  /* Valid Sv39 Virtual Address */
+#else
 /* virtual address we test is in the valid 48-bit portion of the virtual address space */
 #define BAD_VADDR 0x7EDCBA987650
+#endif
 #endif
 #define GOOD_MAGIC 0x15831851
 #define BAD_MAGIC ~GOOD_MAGIC

--- a/apps/sel4test-tests/src/tests/faults.c
+++ b/apps/sel4test-tests/src/tests/faults.c
@@ -42,7 +42,7 @@ enum {
 /* Use a different test virtual address on 32 and 64-bit systems so that we can exercise
    the full address space to make sure fault messages are not truncating fault information. */
 #if CONFIG_WORD_SIZE == 32
-#ifdef CONFIG_ARCH_RISCV_RV32
+#ifdef CONFIG_ARCH_RISCV32
 #define BAD_VADDR 0x7ffedcba    /* 32-bit RISCV userspace */
 #else
 #define BAD_VADDR 0xf123456C


### PR DESCRIPTION
The FRAMEEXPORTS0001 test tries to allocate a 1GiB page. The
rocket-chip only has 256MiB, so the test will fail, even though
the SV39 virtual memory system supports 1GiB mappings.

The PAGEFAULT tests need the virtual address updated to be in
valid virtual memory space on the hardware.

Change-Id: I81a0902033b54528b42e4f653f6bbf1027c31218