### PR TITLE
Catch and handle failure to allocate IRQ

### DIFF
--- a/apps/sel4test-driver/src/main.c
+++ b/apps/sel4test-driver/src/main.c
@@ -556,8 +556,9 @@ static irq_id_t sel4test_timer_irq_register(UNUSED void *cookie, ps_irq_t irq, i
     ZF_LOGF_IF(num_timer_irqs >= MAX_TIMER_IRQS, "Trying to register too many timer IRQs");
 
     /* Allocate the IRQ */
-    seL4_Error serror = sel4platsupport_copy_irq_cap(&env.vka, &env.simple, &irq,
-                                                     &env.timer_irqs[num_timer_irqs].handler_path);
+    error = sel4platsupport_copy_irq_cap(&env.vka, &env.simple, &irq,
+                                         &env.timer_irqs[num_timer_irqs].handler_path);
+    ZF_LOGF_IF(error, "Failed to allocate IRQ handler");
 
     /* Allocate the root notifitcation if we haven't already done so */
     if (env.timer_notification.cptr == seL4_CapNull) {


### PR DESCRIPTION
If an IRQ handler cannot be allocated for a driver, the failure should
be treated as an error rather than silently dropped.

Partial fix for #25