### PR TITLE
settings.cmake: Use OpenSBI instead of BBL

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -18,7 +18,7 @@ list(
 )
 
 set(NANOPB_SRC_ROOT_FOLDER "${project_dir}/tools/nanopb" CACHE INTERNAL "")
-set(BBL_PATH ${project_dir}/tools/riscv-pk CACHE STRING "BBL Folder location")
+set(OPENSBI_PATH "${project_dir}/tools/opensbi" CACHE STRING "OpenSBI Folder location")
 
 set(SEL4_CONFIG_DEFAULT_ADVANCED ON)
 


### PR DESCRIPTION
This is part of a collection of PRs to convert from using the legacy BBL and riscv-pk to OpenSBI.

Other PRs include:
* https://github.com/seL4/seL4/pull/272
* https://github.com/seL4/sel4test/pull/28
* https://github.com/seL4/seL4_tools/pull/46
* https://github.com/seL4/sel4test-manifest/pull/7

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>