### PR TITLE
trivial: change cpio_get_file type

### DIFF
--- a/apps/sel4test-driver/src/main.c
+++ b/apps/sel4test-driver/src/main.c
@@ -408,7 +408,7 @@ void *main_continued(void *arg UNUSED)
 
     unsigned long elf_size;
     unsigned long cpio_len = _cpio_archive_end - _cpio_archive;
-    char *elf_file = cpio_get_file(_cpio_archive, cpio_len, TESTS_APP, &elf_size);
+    const void *elf_file = cpio_get_file(_cpio_archive, cpio_len, TESTS_APP, &elf_size);
     ZF_LOGF_IF(elf_file == NULL, "Error: failed to lookup ELF file");
     int status = elf_newFile(elf_file, elf_size, &tests_elf);
     ZF_LOGF_IF(status, "Error: invalid ELF file");


### PR DESCRIPTION
Recent changes to cpio library require use of
`const void *` now.

Signed-off-by: Oliver Scott <Oliver.Scott@data61.csiro.au>