### PR TITLE
Increase execution time for SCHED0014

### DIFF
--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -1124,9 +1124,9 @@ int test_ordering_periodic_threads(env_t env)
         set_helper_priority(env, &helpers[i], env->priority);
     }
 
-    set_helper_sched_params(env, &helpers[0], 10 * US_IN_MS, 100 * US_IN_MS, 0);
-    set_helper_sched_params(env, &helpers[1], 10 * US_IN_MS, 200 * US_IN_MS, 0);
-    set_helper_sched_params(env, &helpers[2], 10 * US_IN_MS, 800 * US_IN_MS, 0);
+    set_helper_sched_params(env, &helpers[0], 20 * US_IN_MS, 100 * US_IN_MS, 0);
+    set_helper_sched_params(env, &helpers[1], 20 * US_IN_MS, 200 * US_IN_MS, 0);
+    set_helper_sched_params(env, &helpers[2], 20 * US_IN_MS, 800 * US_IN_MS, 0);
 
     for (int i = 0; i < num_threads; i++) {
         start_helper(env, &helpers[i], (helper_fn_t) periodic_thread, i, (seL4_Word) counters, 0, 0);


### PR DESCRIPTION
The time provided to the tasks seems to be exhausted in some occasions before a task can yield on the ODROID-XU with the exynos5410 with debug enabled.

Doubling the budget should not affect periodic scheduling for this test.

Response time analysis for the task set give the following:

 0 - WCET = 20us, min. inter-arrival = 100us, response time = 60us
 1 - WCET = 20us, min. inter-arrival = 200us, response time = 80us
 2 - WCET = 20us, min. inter-arrival = 800us, response time = 260us

Given the response time for each task is less than the inter-arrival time and they all execute at the same priority, they should settle into a regular schedule within the hyperperiod (800us).