### PR TITLE
Ensure server prio greater than client for timeout

### DIFF
--- a/apps/sel4test-tests/src/tests/faults.c
+++ b/apps/sel4test-tests/src/tests/faults.c
@@ -973,6 +973,11 @@ static int test_timeout_fault_in_server(env_t env)
     set_helper_sched_params(env, &client, 0.1 * US_IN_S, US_IN_S, client_data);
     start_helper(env, &client, (helper_fn_t) timeout_fault_client_fn, ep, 0, 0, 0);
 
+    /* Ensure the client doesn't preempt the server when the server is
+     * being reset */
+    set_helper_priority(env, &server, OUR_PRIO - 1);
+    set_helper_priority(env, &client, OUR_PRIO - 2);
+
     /* handle a few faults */
     for (int i = 0; i < 5; i++) {
         ZF_LOGD("Handling fault");

--- a/apps/sel4test-tests/src/tests/faults.c
+++ b/apps/sel4test-tests/src/tests/faults.c
@@ -1057,7 +1057,6 @@ static int test_timeout_fault_nested_servers(env_t env)
 
     return sel4test_get_result();
 }
-/* this test is disabled for the same reason as TIMEOUTFAULT0002 */
 DEFINE_TEST(TIMEOUTFAULT0003, "Nested timeout fault", test_timeout_fault_nested_servers, config_set(CONFIG_KERNEL_MCS))
 
 static void vm_enter(void)


### PR DESCRIPTION
We must ensure that during the reset of the server in the timeout test that the client is not able to preempt the server. If it does, it can perform a send before the server performs a receive. If this occurs, the server will not be blocked when the test thread removes its scheduling context and the test will hang indefinitely.