### PR TITLE
schedcontext: Disable SCHED_CONTEXT_0012

### DIFF
--- a/apps/sel4test-tests/src/tests/schedcontext.c
+++ b/apps/sel4test-tests/src/tests/schedcontext.c
@@ -623,8 +623,9 @@ test_revoke_reply_on_call_chain_unordered(env_t env)
 
     return sel4test_get_result();
 }
+/* Test is disabled on purpose. */
 DEFINE_TEST(SCHED_CONTEXT_0012, "Test revoking a reply on a call chain unorderd",
-            test_revoke_reply_on_call_chain_unordered, config_set(CONFIG_KERNEL_MCS) &&config_set(CONFIG_HAVE_TIMER))
+            test_revoke_reply_on_call_chain_unordered, 0 && config_set(CONFIG_KERNEL_MCS) &&config_set(CONFIG_HAVE_TIMER))
 
 int
 test_revoke_sched_context_on_call_chain(env_t env)


### PR DESCRIPTION
This test was re-enabled following a fix to the test conditional guards.
However upon further investigation, the test was found to be old and was
testing an old implementation of the MCS scheduler. For now, this test
is disabled pending a decision to remove or update it.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>