### PR TITLE
riscv: disable huge page for rocketchip

### DIFF
--- a/apps/sel4test-tests/arch/riscv/arch_frame_type.h
+++ b/apps/sel4test-tests/arch/riscv/arch_frame_type.h
@@ -11,9 +11,12 @@
 
 /* This list must be ordered by size - highest first */
 static const frame_type_t frame_types[] = {
-    /* Rocket-Chip for zedboard only has 256MiB of RAM, so we can't allocate a 1GiB page */
+    /* Rocket-Chip for zedboard and base Rocket-Chip only have 256MiB of RAM, 
+     * so we can't allocate a 1GiB page */
     /* Polarfire has 1GiB of memory can't allocate a 1GiB page for user space */
-#if __riscv_xlen == 64 && !defined(CONFIG_BUILD_ROCKET_CHIP_ZEDBOARD) && !defined(CONFIG_PLAT_ARIANE) &&!defined(CONFIG_PLAT_POLARFIRE)
+#if __riscv_xlen == 64 && !defined(CONFIG_BUILD_ROCKET_CHIP_ZEDBOARD) \
+ && !defined(CONFIG_PLAT_ARIANE) &&!defined(CONFIG_PLAT_POLARFIRE) \
+ && !defined(CONFIG_PLAT_ROCKETCHIP)
     { seL4_RISCV_Giga_Page, 0, seL4_HugePageBits, },
 #endif
     { seL4_RISCV_Mega_Page, 0, seL4_LargePageBits, },


### PR DESCRIPTION
Rocketchip platform only has 256MB of RAM, so we can't allocate
a huge 1GB page.

Signed-off-by: Juan Pablo Ruiz <juanpablo@ssrc.tii.ae>