### PR TITLE
add missing return statement (fix #47)

### DIFF
--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -1652,6 +1652,7 @@ int sched0022_to_fn(struct env *env, helper_thread_t *thread, seL4_CPtr ep)
 
     seL4_SetMR(1, error);
     seL4_Send(ep, tag);
+    return 0;
 }
 
 /* Test that a helper thread can move itself back from another core.


### PR DESCRIPTION
add missing return statement as fix https://github.com/seL4/sel4test/issues/47 for. @yyshen suggested just to return 0 here, but this seem to contradict what all other test are doing.