### PR TITLE
TIMER0001: Reduce test time to 3 seconds

### DIFF
--- a/apps/sel4test-driver/src/tests/timer.c
+++ b/apps/sel4test-driver/src/tests/timer.c
@@ -35,7 +35,7 @@ int test_timer(driver_env_t env)
 {
     uint64_t time = 0;
     test_finished = false;
-    timer_test_data_t test_data = { .goal_count = 10 };
+    timer_test_data_t test_data = { .goal_count = 3 };
 
     int error = tm_alloc_id_at(&env->tm, TIMER_ID);
     test_assert_fatal(!error);


### PR DESCRIPTION
This test used to previously only wait for 3 ticks but an earlier
refactor increased the timeout to 10 seconds for no apparent reason.

Signed-off-by: Kent McLeod <kent@kry10.com>