### PR TITLE
Use the reliable illegal instruction encoding

### DIFF
--- a/apps/sel4test-tests/src/tests/faults.c
+++ b/apps/sel4test-tests/src/tests/faults.c
@@ -394,6 +394,12 @@ do_bad_instruction(void)
         /* Set SP to val. */
         "mv sp, %[valptr]\n\t"
 
+        /* All ones is used as the illegal instruction because it is reasonable
+         * to assume that all current targets support a maximum instruction
+         * length (ILEN) of 32 bits. All zeros was considered and not used
+         * because all ones is easier to validated for the purposes of this
+         * test. Note: on targets that require 32 bit aligned instructions,
+         * this will be 32 bit aligned due to the previous instruction. */
         "bad_instruction_address:\n\t"
         ".word 0xffffffff\n\t"
         "bad_instruction_restart_address:\n\t"


### PR DESCRIPTION
The unprivileged spec says the following:

We consider it a feature that any length of instruction containing all zero bits is not legal, as
this quickly traps erroneous jumps into zeroed memory regions. Similarly, we also reserve the
instruction encoding containing all ones to be an illegal instruction, to catch the other common
pattern observed with unprogrammed non-volatile memory devices, disconnected memory buses,
or broken memory devices.
Software can rely on a naturally aligned 32-bit word containing zero to act as an illegal
instruction on all RISC-V implementations, to be used by software where an illegal instruction
is explicitly desired. Defining a corresponding known illegal value for all ones is more difficult
due to the variable-length encoding. Software cannot generally use the illegal value of ILEN bits
of all 1s, as software might not know ILEN for the eventual target machine (e.g., if software
is compiled into a standard binary library used by many different machines). Defining a 32-bit
word of all ones as illegal was also considered, as all machines must support a 32-bit instruction
size, but this requires the instruction-fetch unit on machines with ILEN>32 report an illegal
instruction exception rather than access fault when such an instruction borders a protection
boundary, complicating variable-instruction-length fetch and decode.

Signed-off-by: Ahmed Charles <acharles@outlook.com>


I'm not sure why this test currently fails on recent versions of QEMU, but I thought that
putting this change up for review might help with figuring that out. I do think that the
zero bit pattern is 'better' because of the statement in the spec.