### PR TITLE
tests: update tests for handler parameters

### DIFF
--- a/apps/sel4test-tests/src/helpers.c
+++ b/apps/sel4test-tests/src/helpers.c
@@ -560,11 +560,11 @@ int restart_after_syscall(env_t env, helper_thread_t *helper)
     return 0;
 }
 
-void set_helper_tfep(env_t env, helper_thread_t *thread, seL4_CPtr tfep)
+void set_helper_tfep(env_t env, helper_thread_t *thread, seL4_CPtr tfep, seL4_Word tfdata, seL4_CapRights_t tfrights)
 {
     ZF_LOGF_IF(!config_set(CONFIG_KERNEL_MCS), "Unsupported on non MCS kernel");
 #ifdef CONFIG_KERNEL_MCS
-    int error = seL4_TCB_SetTimeoutEndpoint(thread->thread.tcb.cptr, tfep);
+    int error = seL4_TCB_SetTimeoutEndpoint(thread->thread.tcb.cptr, tfep, tfdata, tfrights);
     if (error != seL4_NoError) {
         ZF_LOGF("Failed to set tfep\n");
     }

--- a/apps/sel4test-tests/src/helpers.h
+++ b/apps/sel4test-tests/src/helpers.h
@@ -79,7 +79,7 @@ int set_helper_sched_params(UNUSED env_t env, UNUSED helper_thread_t *thread, UN
                             UNUSED uint64_t period, seL4_Word badge);
 
 /* set a helper threads timeout fault handler */
-void set_helper_tfep(env_t env, helper_thread_t *thread, seL4_CPtr tfep);
+void set_helper_tfep(env_t env, helper_thread_t *thread, seL4_CPtr tfep, seL4_Word tfdata, seL4_CapRights_t tfrights);
 
 /* Start a helper. Note: arguments to helper processes will be copied into
  * the address space of that process. Do not pass pointers to data only in

--- a/apps/sel4test-tests/src/tests/breakpoints.c
+++ b/apps/sel4test-tests/src/tests/breakpoints.c
@@ -64,7 +64,7 @@ int setup_faulter_thread_for_test(struct env *env, helper_thread_t *faulter_thre
      */
     error = api_tcb_set_space(
                 get_helper_tcb(faulter_thread),
-                badged_fault_ep_cspath.capPtr,
+                badged_fault_ep_cspath.capPtr, seL4_NilData, seL4_NoRights,
                 env->cspace_root,
                 api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits),
                 env->page_directory, seL4_NilData);

--- a/apps/sel4test-tests/src/tests/cspace.c
+++ b/apps/sel4test-tests/src/tests/cspace.c
@@ -96,7 +96,7 @@ static int test_full_cspace(env_t env)
     test_assert(seL4_GetMR(0) == READY_MAGIC);
 
     /* Now switch its cspace. */
-    error = api_tcb_set_space(get_helper_tcb(&t), t.fault_endpoint,
+    error = api_tcb_set_space(get_helper_tcb(&t), t.fault_endpoint, seL4_NilData, seL4_NoRights,
                               cnode[0], seL4_NilData, env->page_directory,
                               seL4_NilData);
 

--- a/apps/sel4test-tests/src/tests/faults.c
+++ b/apps/sel4test-tests/src/tests/faults.c
@@ -748,7 +748,7 @@ static int test_fault(env_t env, int fault_type, bool inter_as)
 
                 set_helper_priority(env, &handler_thread, 101);
                 error = api_tcb_set_space(get_helper_tcb(&faulter_thread),
-                                          fault_ep,
+                                          fault_ep, seL4_NilData, seL4_NoRights,
                                           faulter_cspace,
                                           api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits),
                                           faulter_vspace, seL4_NilData);
@@ -857,7 +857,7 @@ int test_timeout_fault(env_t env)
 
     create_helper_thread(env, &helper);
     set_helper_sched_params(env, &helper, US_IN_MS, US_IN_S, data);
-    set_helper_tfep(env, &helper, endpoint);
+    set_helper_tfep(env, &helper, endpoint, seL4_NilData, seL4_NoRights);
     start_helper(env, &helper, (helper_fn_t) timeout_fault_0001_fn, 0, 0, 0, 0);
 
     /* wait for timeout fault */
@@ -909,7 +909,7 @@ int create_passive_thread_with_tfep(env_t env, helper_thread_t *passive, seL4_CP
     test_eq(error, seL4_NoError);
 
     error = create_passive_thread(env, passive, fn, ep, arg1, arg2, arg3);
-    set_helper_tfep(env, passive, minted_tfep);
+    set_helper_tfep(env, passive, minted_tfep, seL4_NilData, seL4_NoRights);
     test_eq(error, 0);
 
     /* checkpoint */
@@ -1080,8 +1080,8 @@ static int test_vm_enter_non_vm(env_t env)
     create_helper_thread(env, &helper);
 
     seL4_Word guard = seL4_WordBits - env->cspace_size_bits;
-    err = api_tcb_set_space(get_helper_tcb(&helper), fault_ep, env->cspace_root,
-                            api_make_guard_skip_word(guard),
+    err = api_tcb_set_space(get_helper_tcb(&helper), fault_ep,  seL4_NilData, seL4_NoRights,
+                            env->cspace_root, api_make_guard_skip_word(guard),
                             env->page_directory, seL4_NilData);
     test_eq(err, 0);
 

--- a/apps/sel4test-tests/src/tests/frames.c
+++ b/apps/sel4test-tests/src/tests/frames.c
@@ -155,7 +155,7 @@ static int test_xn(env_t env, seL4_ArchObjectType frame_type)
     create_helper_thread(env, &faulter);
     set_helper_priority(env, &faulter, 100);
     err = api_tcb_set_space(get_helper_tcb(&faulter),
-                            fault_ep,
+                            fault_ep, seL4_NilData, seL4_NoRights,
                             env->cspace_root,
                             api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits),
                             env->page_directory, seL4_NilData);
@@ -195,7 +195,8 @@ static int test_xn(env_t env, seL4_ArchObjectType frame_type)
     create_helper_thread(env, &faulter);
     set_helper_priority(env, &faulter, 100);
     err = api_tcb_configure(get_helper_tcb(&faulter),
-                            fault_ep, seL4_CapNull,
+                            fault_ep, seL4_NilData, seL4_NoRights,
+                            seL4_CapNull, seL4_NilData, seL4_NoRights,
                             get_helper_sched_context(&faulter),
                             env->cspace_root,
                             api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits),
@@ -247,7 +248,8 @@ static int test_device_frame_ipcbuf(env_t env)
     create_helper_thread(env, &other);
     /* Try and create a thread with a device frame as its IPC buffer */
     error = api_tcb_configure(get_helper_tcb(&other),
-                              0, seL4_CapNull,
+                              0, seL4_NilData, seL4_NoRights,
+                              seL4_CapNull, seL4_NilData, seL4_NoRights,
                               get_helper_sched_context(&other),
                               env->cspace_root,
                               api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits),
@@ -347,7 +349,7 @@ static int test_unmap_on_delete(env_t env)
     create_helper_thread(env, &faulter);
     set_helper_priority(env, &faulter, 100);
     err = api_tcb_set_space(get_helper_tcb(&faulter),
-                            fault_ep,
+                            fault_ep, seL4_NilData, seL4_NoRights,
                             env->cspace_root,
                             api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits),
                             env->page_directory, seL4_NilData);

--- a/apps/sel4test-tests/src/tests/ioports.c
+++ b/apps/sel4test-tests/src/tests/ioports.c
@@ -99,7 +99,7 @@ static int test_native_ioports(env_t env)
     set_helper_priority(env, &handler_thread, 100);
 
     error = api_tcb_set_space(get_helper_tcb(&faulter_thread),
-                              fault_ep,
+                              fault_ep, seL4_NilData, seL4_NoRights,
                               faulter_cspace,
                               api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits),
                               faulter_vspace, seL4_NilData);

--- a/apps/sel4test-tests/src/tests/ipc.c
+++ b/apps/sel4test-tests/src/tests/ipc.c
@@ -984,7 +984,7 @@ static int test_fault_handler_donated_sc(env_t env)
 
     /* set fault handler */
     seL4_Word data = api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits);
-    error = api_tcb_set_space(faulter.thread.tcb.cptr, endpoint,
+    error = api_tcb_set_space(faulter.thread.tcb.cptr, endpoint, seL4_NilData, seL4_NoRights,
                               env->cspace_root, data, env->page_directory, seL4_NilData);
     test_eq(error, seL4_NoError);
 

--- a/apps/sel4test-tests/src/tests/ipc_rights.c
+++ b/apps/sel4test-tests/src/tests/ipc_rights.c
@@ -79,7 +79,7 @@ test_recv_needs_read(env_t env)
         create_helper_thread(env, &t);
         int error;
         error = api_tcb_set_space(get_helper_tcb(&t),
-                                  fault_ep,
+                                  fault_ep, seL4_NilData, seL4_NoRights,
                                   env->cspace_root,
                                   seL4_NilData,
                                   env->page_directory, seL4_NilData);

--- a/apps/sel4test-tests/src/tests/multicore.c
+++ b/apps/sel4test-tests/src/tests/multicore.c
@@ -236,7 +236,7 @@ static int smp_test_tlb_instance(env_t env, bool inter_as)
     }
 
     error = api_tcb_set_space(get_helper_tcb(&faulter_thread),
-                              fault_ep_faulter,
+                              fault_ep_faulter, seL4_NilData, seL4_NoRights,
                               faulter_cspace,
                               api_make_guard_skip_word(seL4_WordBits - env->cspace_size_bits),
                               faulter_vspace, seL4_NilData);

--- a/apps/sel4test-tests/src/tests/threads.c
+++ b/apps/sel4test-tests/src/tests/threads.c
@@ -21,7 +21,8 @@ int test_tcb_null_cspace_configure(env_t env)
     create_helper_thread(env, &thread);
 
     /* This should fail because we're passing an invalid CSpace cap. */
-    error = api_tcb_configure(get_helper_tcb(&thread), 0, seL4_CapNull,
+    error = api_tcb_configure(get_helper_tcb(&thread), 0, seL4_NilData, seL4_NoRights,
+                              seL4_CapNull, seL4_NilData, seL4_NoRights,
                               seL4_CapNull, seL4_CapNull,
                               0, env->page_directory,
                               0, 0, 0);
@@ -40,7 +41,7 @@ int test_tcb_null_cspace_setspace(env_t env)
     create_helper_thread(env, &thread);
 
     /* This should fail because we're passing an invalid CSpace cap. */
-    error = api_tcb_set_space(get_helper_tcb(&thread), 0, seL4_CapNull,
+    error = api_tcb_set_space(get_helper_tcb(&thread), 0, 0, seL4_NoRights, seL4_CapNull,
                               0, env->page_directory,
                               0);
 


### PR DESCRIPTION
TCB configuration functions now require two new parameters, which can be used to directly set the fault and timeout handlers badge and rights. This commit updates the tests by setting these parameters to
seL4_NilData and seL4_NoRights, maintaining the previous behaviour.