### PR TITLE
Set SIMULATION for Spike platform by default

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -48,7 +48,7 @@ if(NOT Sel4testAllowSettingsOverride)
         set(KernelArmHypervisorSupport ON CACHE BOOL "" FORCE)
     endif()
 
-    if(KernelPlatformQEMUArmVirt)
+    if(KernelPlatformQEMUArmVirt OR KernelPlatformSpike)
         set(SIMULATION ON CACHE BOOL "" FORCE)
     endif()
 


### PR DESCRIPTION
The following command for building seL4test for the Spike (as documented here https://docs.sel4.systems/Hardware/spike.html) will not compile: `../init-build.sh -DPLATFORM=spike -DRISCV64=1`. This is because the CMake variable `SIMULATION` is not set so seL4test is trying to initialise a timer for the Spike, which isn't implemented. This patch turns `SIMULATION` on for the Spike by default, matching the behaviour for the QEMU AArch64 `virt` platform.