### PR TITLE
SCHED0022: do not request unnecessary refills

### DIFF
--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -1649,7 +1649,7 @@ int sched0022_to_fn(struct env *env, helper_thread_t *thread, seL4_CPtr ep)
                                                 thread->thread.sched_context.cptr,
                                                 10000,
                                                 10000,
-                                                1,
+                                                0,
                                                 0);
     seL4_SetMR(0, error);
     /* and back to core 0 */
@@ -1657,7 +1657,7 @@ int sched0022_to_fn(struct env *env, helper_thread_t *thread, seL4_CPtr ep)
                                      thread->thread.sched_context.cptr,
                                      10000,
                                      10000,
-                                     1,
+                                     0,
                                      0);
 
     seL4_SetMR(1, error);


### PR DESCRIPTION
When this test was introduced in commit beff0afd0bbb6d it requested 1 extra refill in each sched_context_configure call. These extra refills are not necessary to change the core/affinity of the SC and were probably an oversight.

The calls succeed when there is enough space in the SchedContext for at least 4 refills, but fail for 64 bit architectures with the now (seL4/seL4@bb6a00ffe25) tighter minimum SchedContext size where the minimum size works out to exactly 2 refills.

