### PR TITLE
disable timer test for Quartz64

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -79,10 +79,12 @@ if(NOT Sel4testAllowSettingsOverride)
     elseif(
         KernelPlatformZynqmp
         OR KernelPlatformPolarfire
+        OR KernelPlatformQuartz64
         OR (SIMULATION AND (KernelArchRiscV OR KernelArchARM))
     )
         # Frequency settings of the ZynqMP make the ltimer tests problematic
         # Polarfire does not have a complete ltimer implementation
+        # Quartz64 does not have a complete ltimer implementation
         set(Sel4testHaveTimer OFF CACHE BOOL "" FORCE)
     else()
         set(Sel4testHaveTimer ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
According to the comment in https://github.com/seL4/util_libs/pull/117 there is no `ltimer` implementation available. This change should avoid the need for https://github.com/seL4/ci-actions/pull/236

Test with: seL4/seL4#727, seL4/util_libs#117