### PR TITLE
use config_set only for boolean config values

### DIFF
--- a/apps/sel4test-tests/src/tests/fpu.c
+++ b/apps/sel4test-tests/src/tests/fpu.c
@@ -187,4 +187,4 @@ int smp_test_fpu(env_t env)
     return sel4test_get_result();
 }
 DEFINE_TEST(FPU0002, "Test FPU remain valid across core migration", smp_test_fpu,
-            config_set(CONFIG_MAX_NUM_NODES) &&config_set(CONFIG_HAVE_TIMER) &&CONFIG_MAX_NUM_NODES > 1)
+            config_set(CONFIG_HAVE_TIMER) &&(CONFIG_MAX_NUM_NODES > 1))

--- a/apps/sel4test-tests/src/tests/ipc.c
+++ b/apps/sel4test-tests/src/tests/ipc.c
@@ -1361,6 +1361,8 @@ static int test_sched_donation_cross_core(env_t env)
 
     return sel4test_get_result();
 }
-DEFINE_TEST(IPC0028, "Cross core sched donation", test_sched_donation_cross_core,
-            config_set(CONFIG_KERNEL_MCS) &&(CONFIG_MAX_NUM_NODES > 1));
+/* This test currently fails.
+   See https://github.com/seL4/seL4/issues/941 and https://github.com/seL4/seL4/pull/986 */
+DEFINE_TEST(IPC0028, "Cross core sched donation", test_sched_donation_cross_core, false);
+/*            config_set(CONFIG_KERNEL_MCS) &&(CONFIG_MAX_NUM_NODES > 1)); */
 #endif /* CONFIG_KERNEL_MCS */

--- a/apps/sel4test-tests/src/tests/ipc.c
+++ b/apps/sel4test-tests/src/tests/ipc.c
@@ -1362,5 +1362,5 @@ static int test_sched_donation_cross_core(env_t env)
     return sel4test_get_result();
 }
 DEFINE_TEST(IPC0028, "Cross core sched donation", test_sched_donation_cross_core,
-            config_set(CONFIG_KERNEL_MCS) &&config_set(CONFIG_MAX_NUM_NODES) &&CONFIG_MAX_NUM_NODES > 1);
+            config_set(CONFIG_KERNEL_MCS) &&(CONFIG_MAX_NUM_NODES > 1));
 #endif /* CONFIG_KERNEL_MCS */


### PR DESCRIPTION
config_set is true for 1 and false for all other values, so it does not make sense to use with CONFIG_MAX_NUM_NODES.

The two instances where this happened look like they are trying to guard CONFIG_MAX_NUM_NODES > 1 by checking whether CONFIG_MAX_NUM_NODES has any value at all, but doing so incorrectly. CONFIG_MAX_NUM_NODES has a default value of 1 and should always be set to a number, so we can just drop the guard. If this assumption about always having a numbers value is wrong, the code will not compile, which is acceptable.

Thanks to @jearc for spotting these.

This wrong setting has masked two SMP tests, which may now be failing.