### PR TITLE
SCHED0014: fix misleading comment

### DIFF
--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -1113,9 +1113,9 @@ DEFINE_TEST(SCHED0013, "Test two periodic threads", test_two_periodic_threads,
 int test_ordering_periodic_threads(env_t env)
 {
     /*
-     * Set up 3 periodic threads with different budgets.
-     * All 3 threads increment global counters,
-     * check their increments are inline with their budgets.
+     * Set up 3 periodic threads with same budget and different periods.
+     * All 3 threads increment global counters.
+     * We check that their increments are in line with their budgets.
      */
 
     const int num_threads = 3;


### PR DESCRIPTION
The budgets in test SCHED0014 are the same, the periods are different (in relation 1/2/8), and we're checking that the kernel achieves that period relation in scheduling.

In this block in the function `test_ordering_periodic_threads`:
```c
    set_helper_sched_params(env, &helpers[0], 20 * US_IN_MS, 100 * US_IN_MS, 0);
    set_helper_sched_params(env, &helpers[1], 20 * US_IN_MS, 200 * US_IN_MS, 0);
    set_helper_sched_params(env, &helpers[2], 20 * US_IN_MS, 800 * US_IN_MS, 0);
```
the first time parameter is the budget, the second is the period (not the other way around as the comment suggested).