### PR TITLE
Fix: NULL-terminate existing_frames[] array

### DIFF
--- a/apps/sel4test-tests/src/main.c
+++ b/apps/sel4test-tests/src/main.c
@@ -119,13 +119,14 @@ static void init_allocator(env_t env, test_init_data_t *init_data)
     arch_init_allocator(env, init_data);
 
     /* create a vspace */
-    void *existing_frames[init_data->stack_pages + 2];
+    void *existing_frames[init_data->stack_pages + 3];
     existing_frames[0] = (void *) init_data;
     existing_frames[1] = seL4_GetIPCBuffer();
     assert(init_data->stack_pages > 0);
     for (int i = 0; i < init_data->stack_pages; i++) {
         existing_frames[i + 2] = init_data->stack + (i * PAGE_SIZE_4K);
     }
+    existing_frames[init_data->stack_pages + 2] = NULL;
 
     error = sel4utils_bootstrap_vspace(&env->vspace, &alloc_data, init_data->page_directory, &env->vka,
                                        NULL, NULL, existing_frames);


### PR DESCRIPTION
libsel4utils/reserve_initial_task_regions iterates over existing_frames[] and expects it to be null-terminated. Without this commit, the behaviour will rely on whatever the stack had before allocating existing_frames[] in the stack, and subsequent calls may fail, hang, or reserve incorrect frames; depending on the stack values.
