### PR TITLE
aarch64: Minimal update for vspace API change

### DIFF
--- a/apps/sel4test-tests/src/tests/vspace.c
+++ b/apps/sel4test-tests/src/tests/vspace.c
@@ -79,7 +79,11 @@ test_unmap_after_delete(env_t env)
     cspacepath_t path;
     int error;
 
+#if seL4_PGDBits > 0
     seL4_CPtr pgd = vka_alloc_object_leaky(&env->vka, seL4_ARM_PageGlobalDirectoryObject, 0);
+#else
+    seL4_CPtr pgd = 0;
+#endif
     seL4_CPtr pud = vka_alloc_object_leaky(&env->vka, seL4_ARM_PageUpperDirectoryObject, 0);
     seL4_CPtr pd = vka_alloc_object_leaky(&env->vka, seL4_ARM_PageDirectoryObject, 0);
     seL4_CPtr pt = vka_alloc_object_leaky(&env->vka, seL4_ARM_PageTableObject, 0);


### PR DESCRIPTION
The aarch64 vspace API is changed to only have a single pagetable object and capability type for all intermediate page table levels. The root vspace object is still a separate object and capability type.

Test with: https://github.com/seL4/seL4/pull/801
Test with: https://github.com/seL4/seL4_libs/pull/59