### PR TITLE
SCHED0021: allow for simulation tests again

### DIFF
--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -1643,7 +1643,7 @@ static int test_simple_preempt(struct env *env)
 /* This test is flaky under simulation. Probably a race condition that only
    comes out under simulator timing conditions. See also #42  */
 DEFINE_TEST(SCHED0021, "Test for pre-emption during running of many threads with equal prio", test_simple_preempt,
-            !config_set(CONFIG_SIMULATION));
+            true);
 
 int sched0022_to_fn(struct env *env, helper_thread_t *thread, seL4_CPtr ep)
 {


### PR DESCRIPTION
Since e7d9607a0bd reduced the chance of hitting the race condition, this test might be suitable for simulation again.