### PR TITLE
Add a test for injecting an IRQ on a vCPU without a TCB associated

### DIFF
--- a/apps/sel4test-tests/src/tests/vcpu.c
+++ b/apps/sel4test-tests/src/tests/vcpu.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/* This file contains tests related to vCPU syscalls. */
+
+#include <sel4/sel4.h>
+
+#include "../helpers.h"
+
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+int test_vcpu_inject_without_tcb(env_t env)
+{
+    vka_object_t vcpu;
+    int error = vka_alloc_vcpu(&env->vka, &vcpu);
+    assert(!error);
+
+    error = seL4_ARM_VCPU_InjectIRQ(vcpu.cptr, 0, 0, 0, 0);
+    test_eq(error, seL4_NoError);
+
+    return sel4test_get_result();
+}
+DEFINE_TEST(VCPU0001, "Inject IRQ without TCB associated with vCPU", test_vcpu_inject_without_tcb, true)
+#endif


### PR DESCRIPTION
This PR adds a test for a scenario described in https://github.com/seL4/seL4/issues/1199.

Using the following configuration:
`../init-build.sh -DPLATFORM=odroidc4 -DSMP=1 -DARM_HYP=1`

You will currently see the kernel crash:
```
KERNEL DATA ABORT!
Faulting instruction: 0x8000012d38
FAR: 0x3a8 ESR (DFSR): 0x96000004
halting...
Kernel entry via Syscall, number: 1, Call
Cap type: 15, Invocation tag: 48
```

This test is ARM specific. I believe there are no other vCPU tests in sel4test right now so I added a new file.
