### PR TITLE
Allow setting NANOPB_SRC_ROOT_FOLDER 

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -17,7 +17,7 @@ list(
         ${project_modules}
 )
 
-set(NANOPB_SRC_ROOT_FOLDER "${project_dir}/tools/nanopb" CACHE INTERNAL "")
+set(NANOPB_SRC_ROOT_FOLDER "${project_dir}/tools/nanopb" CACHE STRING "NanoPB Folder location")
 set(OPENSBI_PATH "${project_dir}/tools/opensbi" CACHE STRING "OpenSBI Folder location")
 
 set(SEL4_CONFIG_DEFAULT_ADVANCED ON)

--- a/settings.cmake
+++ b/settings.cmake
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.7.2)
 
-set(project_dir "${CMAKE_CURRENT_LIST_DIR}/../../")
+set(project_dir "${CMAKE_CURRENT_LIST_DIR}/../..")
 file(GLOB project_modules ${project_dir}/projects/*)
 list(
     APPEND


### PR DESCRIPTION
- in CMake, `INTERNAL` has the same effect as `FORCE`, so passing any `-DNANOPB_SRC_ROOT_FOLDER=...` to CMake on the command line will be overwritten and there is no way to customize the path then.
- the second commit removes the trailing slash of the variable, which seem more a cosmetic thing. Having a "//" on some paths in the variables that are created later seems not to cause any practical issues.