### PR TITLE
remove explicit newline in ZF_LOGx()

### DIFF
--- a/apps/sel4test-driver/src/main.c
+++ b/apps/sel4test-driver/src/main.c
@@ -184,7 +184,7 @@ static void init_timer(void)
         ZF_LOGF_IF(error, "Failed to allocate notification object for tests");
 
         error = seL4_TCB_BindNotification(simple_get_tcb(&env.simple), env.timer_notification.cptr);
-        ZF_LOGF_IF(error, "Failed to bind timer notification to sel4test-driver\n");
+        ZF_LOGF_IF(error, "Failed to bind timer notification to sel4test-driver");
 
         /* set up the timer manager */
         tm_init(&env.tm, &env.ltimer, &env.ops, 1);
@@ -323,7 +323,7 @@ void sel4test_run_tests(struct driver_env *e)
     /* Extract and filter the tests based on the regex */
     regex_t reg;
     int error = regcomp(&reg, CONFIG_TESTPRINTER_REGEX, REG_EXTENDED | REG_NOSUB);
-    ZF_LOGF_IF(error, "Error compiling regex \"%s\"\n", CONFIG_TESTPRINTER_REGEX);
+    ZF_LOGF_IF(error, "Error compiling regex \"%s\"", CONFIG_TESTPRINTER_REGEX);
 
     int skipped_tests = 0;
     /* get all the tests in the test case section in the driver */

--- a/apps/sel4test-driver/src/tests/timer.c
+++ b/apps/sel4test-driver/src/tests/timer.c
@@ -45,7 +45,7 @@ int test_timer(driver_env_t env)
 
     while (!test_finished) {
         wait_for_timer_interrupt(env);
-        ZF_LOGV("Tick\n");
+        ZF_LOGV("Tick");
         error = tm_update(&env->tm);
         test_assert_fatal(!error);
     }
@@ -78,7 +78,7 @@ test_gettime_timeout(driver_env_t env)
 
     while (!test_finished) {
         wait_for_timer_interrupt(env);
-        ZF_LOGV("Tick\n");
+        ZF_LOGV("Tick");
         error = tm_update(&env->tm);
         test_assert_fatal(!error);
     }

--- a/apps/sel4test-driver/src/testtypes.c
+++ b/apps/sel4test-driver/src/testtypes.c
@@ -19,19 +19,19 @@
 /* Bootstrap test type. */
 static inline void bootstrap_set_up_test_type(uintptr_t e)
 {
-    ZF_LOGD("setting up bootstrap test type\n");
+    ZF_LOGD("setting up bootstrap test type");
 }
 static inline void bootstrap_tear_down_test_type(uintptr_t e)
 {
-    ZF_LOGD("tearing down bootstrap test type\n");
+    ZF_LOGD("tearing down bootstrap test type");
 }
 static inline void bootstrap_set_up(uintptr_t e)
 {
-    ZF_LOGD("set up bootstrap test\n");
+    ZF_LOGD("set up bootstrap test");
 }
 static inline void bootstrap_tear_down(uintptr_t e)
 {
-    ZF_LOGD("tear down bootstrap test\n");
+    ZF_LOGD("tear down bootstrap test");
 }
 static inline test_result_t bootstrap_run_test(struct testcase *test, uintptr_t e)
 {

--- a/apps/sel4test-driver/src/timer.c
+++ b/apps/sel4test-driver/src/timer.c
@@ -78,7 +78,7 @@ void wait_for_timer_interrupt(driver_env_t env)
 void timeout(driver_env_t env, uint64_t ns, timeout_type_t timeout_type)
 {
     if (config_set(CONFIG_HAVE_TIMER)) {
-        ZF_LOGD_IF(timeServer_timeoutPending, "Overwriting a previous timeout request\n");
+        ZF_LOGD_IF(timeServer_timeoutPending, "Overwriting a previous timeout request");
         timeServer_timeoutType = timeout_type;
         int error = tm_register_cb(&env->tm, timeout_type, ns, 0,
                                    TIMER_ID, timeout_cb, env->timer_notify_test.cptr);

--- a/apps/sel4test-tests/src/helpers.c
+++ b/apps/sel4test-tests/src/helpers.c
@@ -33,7 +33,7 @@ int check_zeroes(seL4_Word addr, seL4_Word size_bytes)
     seL4_Word size_words = size_bytes / sizeof(seL4_Word);
     while (size_words--) {
         if (*p++ != 0) {
-            ZF_LOGE("Found non-zero at position %ld: %lu\n", ((long)p) - (addr), (unsigned long)p[-1]);
+            ZF_LOGE("Found non-zero at position %ld: %lu", ((long)p) - (addr), (unsigned long)p[-1]);
             return 0;
         }
     }
@@ -432,7 +432,7 @@ static void sel4test_send_time_request(seL4_CPtr ep, uint64_t ns, sel4test_outpu
         tag = seL4_MessageInfo_new(0, 0, 0, 1);
         break;
     default:
-        ZF_LOGE("Invalid time request\n");
+        ZF_LOGE("Invalid time request");
         break;
     }
 
@@ -566,7 +566,7 @@ void set_helper_tfep(env_t env, helper_thread_t *thread, seL4_CPtr tfep)
 #ifdef CONFIG_KERNEL_MCS
     int error = seL4_TCB_SetTimeoutEndpoint(thread->thread.tcb.cptr, tfep);
     if (error != seL4_NoError) {
-        ZF_LOGF("Failed to set tfep\n");
+        ZF_LOGF("Failed to set tfep");
     }
 #endif
 }

--- a/apps/sel4test-tests/src/main.c
+++ b/apps/sel4test-tests/src/main.c
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
         result = test->function((uintptr_t)&env);
     } else {
         result = FAILURE;
-        ZF_LOGF("Cannot find test %s\n", init_data->name);
+        ZF_LOGF("Cannot find test %s", init_data->name);
     }
 
     printf("Test %s %s\n", init_data->name, result == SUCCESS ? "passed" : "failed");

--- a/apps/sel4test-tests/src/tests/schedcontext.c
+++ b/apps/sel4test-tests/src/tests/schedcontext.c
@@ -352,18 +352,18 @@ DEFINE_TEST(SCHED_CONTEXT_0007, "test resuming a passive thread and binding sche
 static void
 sched_context0008_client_fn(seL4_CPtr send_ep, seL4_CPtr wait_ep)
 {
-    ZF_LOGD("Client send\n");
+    ZF_LOGD("Client send");
     api_nbsend_wait(send_ep, seL4_MessageInfo_new(0, 0, 0, 0), wait_ep, NULL);
 }
 
 static void sched_context0008_proxy_fn(seL4_CPtr send_ep, seL4_CPtr wait_ep)
 {
     /* signal to test runner that we are initialised and waiting for client */
-    ZF_LOGD("Proxy init\n");
+    ZF_LOGD("Proxy init");
     api_nbsend_wait(send_ep, seL4_MessageInfo_new(0, 0, 0, 0), wait_ep, NULL);
 
     /* forward on the message we got */
-    ZF_LOGD("Proxy fwd\n");
+    ZF_LOGD("Proxy fwd");
     api_nbsend_wait(send_ep, seL4_MessageInfo_new(0, 0, 0, 0), wait_ep, NULL);
 
     ZF_LOGF("Should not get here");
@@ -371,10 +371,10 @@ static void sched_context0008_proxy_fn(seL4_CPtr send_ep, seL4_CPtr wait_ep)
 
 static void sched_context0008_server_fn(seL4_CPtr init_ep, seL4_CPtr wait_ep)
 {
-    ZF_LOGD("Server init\n");
+    ZF_LOGD("Server init");
     /* tell test runner we are done by sending to init ep, then wait for proxy message */
     api_nbsend_wait(init_ep, seL4_MessageInfo_new(0, 0, 0, 0), wait_ep, NULL);
-    ZF_LOGD("Server exit\n");
+    ZF_LOGD("Server exit");
     /* hold on to scheduling context */
 }
 static int test_delete_sendwait_tcb(env_t env)
@@ -386,28 +386,28 @@ static int test_delete_sendwait_tcb(env_t env)
     seL4_CPtr server_ep = vka_alloc_endpoint_leaky(&env->vka);
 
     /* set up and start server */
-    ZF_LOGD("Create server\n");
+    ZF_LOGD("Create server");
     int error = create_passive_thread(env, &server, (helper_fn_t) sched_context0008_server_fn,
                                       server_ep, proxy_send, 0, 0);
     test_eq(error, 0);
 
     /* setup and start proxy */
-    ZF_LOGD("Create proxy\n");
+    ZF_LOGD("Create proxy");
     error = create_passive_thread(env, &proxy, (helper_fn_t) sched_context0008_proxy_fn, proxy_send,
                                   client_send, 0, 0);
     test_eq(error, 0);
 
-    ZF_LOGD("Create client\n");
+    ZF_LOGD("Create client");
     /* create and start the client */
     create_helper_thread(env, &client);
     start_helper(env, &client, (helper_fn_t) sched_context0008_client_fn, client_send,
                  client_wait, 0, 0);
 
-    ZF_LOGD("Wait for server\n");
+    ZF_LOGD("Wait for server");
     /* wait for the server to finish, who has stolen the scheduling context */
     wait_for_helper(&server);
 
-    ZF_LOGD("Kill server\n");
+    ZF_LOGD("Kill server");
     /* kill the server */
     vka_free_object(&env->vka, &server.thread.tcb);
 
@@ -415,10 +415,10 @@ static int test_delete_sendwait_tcb(env_t env)
     error = api_sc_bind(client.thread.sched_context.cptr, client.thread.tcb.cptr);
     test_eq(error, seL4_NoError);
 
-    ZF_LOGD("Signal client\n");
+    ZF_LOGD("Signal client");
     seL4_Signal(client_wait);
 
-    ZF_LOGD("Wait for client\n");
+    ZF_LOGD("Wait for client");
     /* now the client should finish */
     wait_for_helper(&client);
 
@@ -430,7 +430,7 @@ DEFINE_TEST(SCHED_CONTEXT_0008, "Test deleting a tcb running on donated sc",
 void
 sched_context_0009_server_fn(seL4_CPtr ep, volatile int *state, seL4_CPtr reply)
 {
-    ZF_LOGD("Server init\n");
+    ZF_LOGD("Server init");
     api_nbsend_recv(ep, seL4_MessageInfo_new(0, 0, 0, 0), ep, NULL, reply);
     while (1) {
         *state = *state + 1;
@@ -439,7 +439,7 @@ sched_context_0009_server_fn(seL4_CPtr ep, volatile int *state, seL4_CPtr reply)
 
 void sched_context_0009_client_fn(seL4_CPtr ep, volatile int *state)
 {
-    ZF_LOGD("Client call\n");
+    ZF_LOGD("Client call");
     seL4_Call(ep, seL4_MessageInfo_new(0, 0, 0, 0));
     if (state != NULL) {
         *state = *state + 1;
@@ -487,7 +487,7 @@ int test_sched_context_goes_to_to_caller_on_reply_cap_delete(env_t env)
     /* save and resume client */
     restart_after_syscall(env, &client);
 
-    printf("Waiting for client\n");
+    printf("Waiting for client");
     wait_for_helper(&client);
 
     return sel4test_get_result();
@@ -543,7 +543,7 @@ int test_sched_context_unbind_server(env_t env)
     /* save and resume client */
     restart_after_syscall(env, &client);
 
-    printf("Waiting for client\n");
+    printf("Waiting for client");
     wait_for_helper(&client);
 
     return sel4test_get_result();
@@ -554,13 +554,13 @@ DEFINE_TEST(SCHED_CONTEXT_0010, "Test unbinding scheduling context from server",
 void
 sched_context_0011_proxy_fn(seL4_CPtr in, seL4_CPtr out, seL4_CPtr reply)
 {
-    ZF_LOGD("Proxy init\n");
+    ZF_LOGD("Proxy init");
     api_nbsend_recv(in, seL4_MessageInfo_new(0, 0, 0, 0), in, NULL, reply);
 
-    ZF_LOGD("Proxy call\n");
+    ZF_LOGD("Proxy call");
     seL4_Call(out, seL4_MessageInfo_new(0, 0, 0, 0));
 
-    ZF_LOGD("Proxy here\n");
+    ZF_LOGD("Proxy here");
 }
 
 int test_revoke_reply_on_call_chain_returns_sc(env_t env)
@@ -602,7 +602,7 @@ int test_revoke_reply_on_call_chain_returns_sc(env_t env)
     /* save and resume client */
     restart_after_syscall(env, &client);
 
-    ZF_LOGD("Waiting for client\n");
+    ZF_LOGD("Waiting for client");
     wait_for_helper(&client);
 
     return sel4test_get_result();
@@ -642,7 +642,7 @@ test_revoke_reply_on_call_chain_unordered(env_t env)
     test_eq(error, seL4_NoError);
 
     /* kill the servers reply cap */
-    ZF_LOGD("Nuke server reply cap\n");
+    ZF_LOGD("Nuke server reply cap");
     error = cnode_delete(env, server_reply);
     test_eq(error, seL4_NoError);
 
@@ -712,7 +712,7 @@ test_revoke_sched_context_on_call_chain(env_t env)
 
     restart_after_syscall(env, &proxy);
 
-    ZF_LOGD("Waiting for proxy\n");
+    ZF_LOGD("Waiting for proxy");
     wait_for_helper(&proxy);
 
     error = api_sc_unbind_object(sched_context, proxy.thread.tcb.cptr);
@@ -724,7 +724,7 @@ test_revoke_sched_context_on_call_chain(env_t env)
 
     restart_after_syscall(env, &client);
 
-    ZF_LOGD("Waiting for Client\n");
+    ZF_LOGD("Waiting for Client");
     wait_for_helper(&client);
 
     return sel4test_get_result();

--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -239,13 +239,13 @@ static int test_suspend(struct env *env)
     set_helper_priority(env, &thread2b, 101);
 
     suspend_test_step = 0;
-    ZF_LOGD("      ");
+    ZF_LOGD("Waiting...");
 
     wait_for_helper(&thread1);
     wait_for_helper(&thread2b);
 
     CHECK_STEP(suspend_test_step, 6);
-    ZF_LOGD("\n");
+    ZF_LOGD("Suspended\n");
 
     cleanup_helper(env, &thread1);
     cleanup_helper(env, &thread2a);

--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -43,7 +43,7 @@ static int test_thread_suspend(env_t env)
 {
     helper_thread_t t1;
     volatile seL4_Word counter;
-    ZF_LOGD("test_thread_suspend\n");
+    ZF_LOGD("test_thread_suspend");
     create_helper_thread(env, &t1);
 
     set_helper_priority(env, &t1, 100);
@@ -110,11 +110,11 @@ DEFINE_TEST(SCHED0000, "Test suspending and resuming a thread (flaky)", test_thr
 static int
 test_resume_self(struct env *env)
 {
-    ZF_LOGD("Starting test_resume_self\n");
+    ZF_LOGD("Starting test_resume_self");
     /* Ensure nothing bad happens if we resume ourselves. */
     int error = seL4_TCB_Resume(env->tcb);
     test_error_eq(error, seL4_NoError);
-    ZF_LOGD("Ending test_resume_self\n");
+    ZF_LOGD("Ending test_resume_self");
     return sel4test_get_result();
 }
 DEFINE_TEST(SCHED0002, "Test resuming ourselves", test_resume_self, true)
@@ -201,10 +201,10 @@ static int test_suspend(struct env *env)
     helper_thread_t thread2a;
     helper_thread_t thread2b;
 
-    ZF_LOGD("Starting test_suspend\n");
+    ZF_LOGD("Starting test_suspend");
 
     create_helper_thread(env, &thread1);
-    ZF_LOGD("Show me\n");
+    ZF_LOGD("Show me");
     create_helper_thread(env, &thread2a);
 
     create_helper_thread(env, &thread2b);
@@ -245,7 +245,7 @@ static int test_suspend(struct env *env)
     wait_for_helper(&thread2b);
 
     CHECK_STEP(suspend_test_step, 6);
-    ZF_LOGD("Suspended\n");
+    ZF_LOGD("Suspended");
 
     cleanup_helper(env, &thread1);
     cleanup_helper(env, &thread2a);


### PR DESCRIPTION
- remove explicit newline in `ZF_LOGx()`, the functions already prints a newline at the end.
- SCHED0003: log debug information instead of empty lines
