### PR TITLE
scheduler: resume does preempt

### DIFF
--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -182,14 +182,6 @@ static int suspend_test_helper_1(seL4_CPtr t1, seL4_CPtr t2a, seL4_CPtr t2b)
 
     /* We should have been preempted immediately, so by the time we run again,
      * the suspend_test_step should be 5. */
-
-#if 1 // WE HAVE A BROKEN SCHEDULER IN SEL4
-    /* FIXME: The seL4 scheduler is broken, and seL4_TCB_Resume will not
-     * preempt. The only way to get preempted is to force it ourselves (or wait
-     * for a timer tick). */
-    seL4_Yield();
-#endif
-
     CHECK_STEP(suspend_test_step, 5);
 
     return sel4test_get_result();


### PR DESCRIPTION
If we're seeing failures on this test, they need to be investigated. The resume invocation is definitely supposed to call the scheduler and leave with the highest priority thread running.

This "fix" was added before the release in 2014 and I don't have history copy of sel4test, so if anybody remembers what this might have been about, please do comment.