### PR TITLE
(don't merge) Remove const qualifiers from domain schedule variables

### DIFF
--- a/domain_schedule.c
+++ b/domain_schedule.c
@@ -21,7 +21,7 @@
 #include <model/statedata.h>
 
 /* Default schedule. */
-const dschedule_t ksDomSchedule[] = {
+dschedule_t ksDomSchedule[] = {
     { .domain = 0, .length = 60 },
 #if CONFIG_NUM_DOMAINS > 1
     { .domain = 1, .length = 4 },
@@ -73,4 +73,4 @@ const dschedule_t ksDomSchedule[] = {
 #endif
 };
 
-const word_t ksDomScheduleLength = sizeof(ksDomSchedule) / sizeof(dschedule_t);
+word_t ksDomScheduleLength = sizeof(ksDomSchedule) / sizeof(dschedule_t);


### PR DESCRIPTION
This PR removes the const qualifiers from the variables in domain_schedule.c, so that it may be compiled with a kernel that also lacks const qualifiers on these variables (see https://github.com/seL4/seL4/pull/1308).