### PR TITLE
Cheshire (CVA6) support

### DIFF
--- a/apps/sel4test-tests/arch/riscv/arch_frame_type.h
+++ b/apps/sel4test-tests/arch/riscv/arch_frame_type.h
@@ -15,7 +15,8 @@ static const frame_type_t frame_types[] = {
     * so we can't allocate a 1GiB page for this test.
     * Polarfire has 1GiB of memory can't allocate a 1GiB page for user space */
 #if __riscv_xlen == 64 && !defined(CONFIG_PLAT_ROCKETCHIP) \
- && !defined(CONFIG_PLAT_ARIANE) &&!defined(CONFIG_PLAT_POLARFIRE)
+ && !defined(CONFIG_PLAT_ARIANE) &&!defined(CONFIG_PLAT_POLARFIRE) \
+ && !defined(CONFIG_PLAT_CHESHIRE)
     { seL4_RISCV_Giga_Page, 0, seL4_HugePageBits, },
 #endif
     { seL4_RISCV_Mega_Page, 0, seL4_LargePageBits, },

--- a/settings.cmake
+++ b/settings.cmake
@@ -82,6 +82,7 @@ if(NOT Sel4testAllowSettingsOverride)
         OR KernelPlatformQuartz64
         OR KernelPlatformRocketchip
         OR KernelPlatformRocketchipZCU102
+        OR KernelPlatformCheshire
         OR (SIMULATION AND (KernelArchRiscV OR KernelArchARM))
     )
         # Frequency settings of the ZynqMP make the ltimer tests problematic


### PR DESCRIPTION
This PR adds build support for the Cheshire RISCV64 SoC. This system requires that huge page tests and the timer tests be disabled as the RAM is too small on the target FPGA (Digilent Genesys 2) and there are no hardware timers in Cheshire respectively. This PR requires the following PRs to merge before it can be used standalone:
https://github.com/seL4/seL4/pull/1354
https://github.com/seL4/util_libs/pull/188