### PR TITLE
ltimer: use platsupport export where it makes sense

### DIFF
--- a/apps/sel4test-driver/CMakeLists.txt
+++ b/apps/sel4test-driver/CMakeLists.txt
@@ -10,24 +10,6 @@ project(sel4test-driver C)
 
 set(configure_string "")
 
-config_option(Sel4testHaveTimer HAVE_TIMER "Enable tests that require a timer driver" DEFAULT ON)
-
-config_option(Sel4testSimulation SIMULATION "Disable tests not suitable for simulation" DEFAULT OFF)
-
-config_option(
-    Sel4testHaveCache
-    HAVE_CACHE
-    "Enable tests that require a functioning cache"
-    DEFAULT
-    ON
-)
-if(Sel4testAllowSettingsOverride)
-    mark_as_advanced(CLEAR Sel4testHaveTimer Sel4testHaveCache)
-else()
-    mark_as_advanced(FORCE Sel4testHaveTimer Sel4testHaveCache)
-endif()
-add_config_library(sel4test-driver "${configure_string}")
-
 find_package(musllibc REQUIRED)
 find_package(util_libs REQUIRED)
 find_package(seL4_libs REQUIRED)
@@ -47,6 +29,40 @@ sel4_libs_import_libraries()
 set(LibNanopb ON CACHE BOOL "" FORCE)
 sel4_projects_libs_import_libraries()
 add_subdirectory(../../libsel4testsupport libsel4testsupport)
+
+if(
+    # Platform does not support timers
+    (NOT LibPlatSupportHaveTimer)
+    # Frequency settings of the ZynqMP make the ltimer tests problematic
+    OR KernelPlatformZynqmp
+    # Polarfire does not have a complete ltimer implementation
+    OR KernelPlatformPolarfire
+    # Quartz64 does not have a complete ltimer implementation
+    OR KernelPlatformQuartz64
+)
+    set(Sel4testHaveTimer OFF CACHE BOOL "" FORCE)
+else()
+    set(Sel4testHaveTimer ON CACHE BOOL "" FORCE)
+endif()
+
+config_option(Sel4testHaveTimer HAVE_TIMER "Enable tests that require a timer driver" DEFAULT ON)
+
+config_option(Sel4testSimulation SIMULATION "Disable tests not suitable for simulation" DEFAULT OFF)
+
+config_option(
+    Sel4testHaveCache
+    HAVE_CACHE
+    "Enable tests that require a functioning cache"
+    DEFAULT
+    ON
+)
+if(Sel4testAllowSettingsOverride)
+    mark_as_advanced(CLEAR Sel4testHaveTimer Sel4testHaveCache)
+else()
+    mark_as_advanced(FORCE Sel4testHaveTimer Sel4testHaveCache)
+endif()
+
+add_config_library(sel4test-driver "${configure_string}")
 
 file(
     GLOB

--- a/apps/sel4test-driver/CMakeLists.txt
+++ b/apps/sel4test-driver/CMakeLists.txt
@@ -34,10 +34,12 @@ if(
     # Platform does not support timers
     (NOT LibPlatSupportHaveTimer)
     # Frequency settings of the ZynqMP make the ltimer tests problematic
-    OR KernelPlatformZynqmp
-    # Polarfire does not have a complete ltimer implementation
-    OR KernelPlatformPolarfire
-    # Quartz64 does not have a complete ltimer implementation
+    OR
+        KernelPlatformZynqmp
+        # Polarfire does not have a complete ltimer implementation
+    OR
+        KernelPlatformPolarfire
+        # Quartz64 does not have a complete ltimer implementation
     OR KernelPlatformQuartz64
 )
     set(Sel4testHaveTimer OFF CACHE BOOL "" FORCE)

--- a/settings.cmake
+++ b/settings.cmake
@@ -77,30 +77,6 @@ if(NOT Sel4testAllowSettingsOverride)
         set(Sel4testHaveCache ON CACHE BOOL "" FORCE)
     endif()
 
-    if(KernelPlatformQEMUArmVirt)
-        if(KernelArmExportPCNTUser AND KernelArmExportPTMRUser)
-            set(Sel4testHaveTimer ON CACHE BOOL "" FORCE)
-        else()
-            set(Sel4testHaveTimer OFF CACHE BOOL "" FORCE)
-        endif()
-    elseif(
-        KernelPlatformZynqmp
-        OR KernelPlatformPolarfire
-        OR KernelPlatformQuartz64
-        OR KernelPlatformRocketchip
-        OR KernelPlatformRocketchipZCU102
-        OR KernelPlatformCheshire
-        OR (SIMULATION AND (KernelArchRiscV OR KernelArchARM))
-    )
-        # Frequency settings of the ZynqMP make the ltimer tests problematic
-        # Polarfire does not have a complete ltimer implementation
-        # Quartz64 does not have a complete ltimer implementation
-        # Rocket Chip on the ZCU102 FPGA does not have a timer peripheral
-        set(Sel4testHaveTimer OFF CACHE BOOL "" FORCE)
-    else()
-        set(Sel4testHaveTimer ON CACHE BOOL "" FORCE)
-    endif()
-
     # Check the hardware debug API non simulated (except for ia32, which can be simulated),
     # or platforms that don't support it.
     if(((NOT SIMULATION) OR KernelSel4ArchIA32) AND NOT KernelHardwareDebugAPIUnsupported)


### PR DESCRIPTION
This is a nonfunctional change, purely a decoupling of configs. Depends on https://github.com/seL4/util_libs/pull/196 to be merged first.

Test with: https://github.com/seL4/util_libs/pull/196

---

In libplatsupport, we know which platforms do not support an ltimer implementation, so rather than duplicating them, we can re-use the cmake config variable here.

However, this needs to be moved after util_libs_import_libraries() for the config to appear, but before config_option for it to be generated in the gen_config.h file.

I have tested this with:

- maaxboard (supports timer, tests enabled)
- zynqmp (supports timer, tests disabled)
- cheshire (no timer support, tests disabled)