### PR TITLE
settings: hardware debug API only for debug builds

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -77,9 +77,9 @@ if(NOT Sel4testAllowSettingsOverride)
         set(Sel4testHaveCache ON CACHE BOOL "" FORCE)
     endif()
 
-    # Check the hardware debug API non simulated (except for ia32, which can be simulated),
-    # or platforms that don't support it.
-    if(((NOT SIMULATION) OR KernelSel4ArchIA32) AND NOT KernelHardwareDebugAPIUnsupported)
+    # Test hardware debug API on non-simulation debug configs.
+    # IA32 simulation does support it, so allow there.
+    if(DEBUG AND ((NOT SIMULATION) OR KernelSel4ArchIA32) AND NOT KernelHardwareDebugAPIUnsupported)
         set(HardwareDebugAPI ON CACHE BOOL "" FORCE)
     else()
         set(HardwareDebugAPI OFF CACHE BOOL "" FORCE)

--- a/settings.cmake
+++ b/settings.cmake
@@ -8,14 +8,8 @@ cmake_minimum_required(VERSION 3.16.0)
 
 set(project_dir "${CMAKE_CURRENT_LIST_DIR}/../..")
 file(GLOB project_modules ${project_dir}/projects/*)
-list(
-    APPEND
-        CMAKE_MODULE_PATH
-        ${project_dir}/kernel
-        ${project_dir}/tools/seL4/cmake-tool/helpers/
-        ${project_dir}/tools/seL4/elfloader-tool/
-        ${project_modules}
-)
+list(APPEND CMAKE_MODULE_PATH ${project_dir}/kernel ${project_dir}/tools/seL4/cmake-tool/helpers/
+     ${project_dir}/tools/seL4/elfloader-tool/ ${project_modules})
 
 set(NANOPB_SRC_ROOT_FOLDER "${project_dir}/tools/nanopb" CACHE STRING "NanoPB Folder location")
 set(OPENSBI_PATH "${project_dir}/tools/opensbi" CACHE STRING "OpenSBI Folder location")
@@ -34,7 +28,7 @@ sel4_configure_platform_settings()
 set(valid_platforms ${KernelPlatform_all_strings} ${correct_platform_strings_platform_aliases})
 set_property(CACHE PLATFORM PROPERTY STRINGS ${valid_platforms})
 if(NOT "${PLATFORM}" IN_LIST valid_platforms)
-    message(FATAL_ERROR "Invalid PLATFORM selected: \"${PLATFORM}\"
+  message(FATAL_ERROR "Invalid PLATFORM selected: \"${PLATFORM}\"
 Valid platforms are: \"${valid_platforms}\"")
 endif()
 
@@ -42,77 +36,77 @@ endif()
 # the specific test values. By default it is disabled
 set(Sel4testAllowSettingsOverride OFF CACHE BOOL "Allow user to override configuration settings")
 if(NOT Sel4testAllowSettingsOverride)
-    # We use 'FORCE' when settings these values instead of 'INTERNAL' so that they still appear
-    # in the cmake-gui to prevent excessively confusing users
-    if(ARM_HYP)
-        set(KernelArmHypervisorSupport ON CACHE BOOL "" FORCE)
-    endif()
+  # We use 'FORCE' when settings these values instead of 'INTERNAL' so that they still appear
+  # in the cmake-gui to prevent excessively confusing users
+  if(ARM_HYP)
+    set(KernelArmHypervisorSupport ON CACHE BOOL "" FORCE)
+  endif()
 
-    if(KernelSel4ArchAarch32)
-        set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
-    endif()
-    if(KernelSel4ArchAarch64)
-        set(KernelArmTLSReg tpidru CACHE STRING "" FORCE)
-    endif()
+  if(KernelSel4ArchAarch32)
+    set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
+  endif()
+  if(KernelSel4ArchAarch64)
+    set(KernelArmTLSReg tpidru CACHE STRING "" FORCE)
+  endif()
 
-    if(KernelPlatformQEMUArmVirt OR KernelPlatformQEMURiscVVirt OR KernelPlatformSpike)
-        set(SIMULATION ON CACHE BOOL "" FORCE)
-    endif()
+  if(KernelPlatformQEMUArmVirt OR KernelPlatformQEMURiscVVirt OR KernelPlatformSpike)
+    set(SIMULATION ON CACHE BOOL "" FORCE)
+  endif()
 
-    if(SIMULATION)
-        ApplyCommonSimulationSettings(${KernelSel4Arch})
+  if(SIMULATION)
+    ApplyCommonSimulationSettings(${KernelSel4Arch})
+  else()
+    if(KernelArchX86)
+      set(KernelIOMMU ON CACHE BOOL "" FORCE)
+    endif()
+  endif()
+
+  # sel4test specific config settings.
+
+  if(SIMULATION)
+    set(Sel4testSimulation ON CACHE BOOL "" FORCE)
+    set(Sel4testHaveCache OFF CACHE BOOL "" FORCE)
+  else()
+    set(Sel4testSimulation OFF CACHE BOOL "" FORCE)
+    set(Sel4testHaveCache ON CACHE BOOL "" FORCE)
+  endif()
+
+  # Test hardware debug API on non-simulation debug configs.
+  # IA32 simulation does support it, so allow there.
+  if(DEBUG AND ((NOT SIMULATION) OR KernelSel4ArchIA32) AND NOT KernelHardwareDebugAPIUnsupported)
+    set(HardwareDebugAPI ON CACHE BOOL "" FORCE)
+  else()
+    set(HardwareDebugAPI OFF CACHE BOOL "" FORCE)
+  endif()
+
+  ApplyCommonReleaseVerificationSettings(${RELEASE} ${VERIFICATION})
+
+  if(BAMBOO)
+    set(LibSel4TestPrintXML ON CACHE BOOL "" FORCE)
+  else()
+    set(LibSel4TestPrintXML OFF CACHE BOOL "" FORCE)
+  endif()
+
+  if(DOMAINS)
+    set(KernelNumDomains 4 CACHE STRING "" FORCE)
+  else()
+    set(KernelNumDomains 1 CACHE STRING "" FORCE)
+  endif()
+
+  if(SMP)
+    if(NUM_NODES MATCHES "^[0-9]+$")
+      set(KernelMaxNumNodes ${NUM_NODES} CACHE STRING "" FORCE)
     else()
-        if(KernelArchX86)
-            set(KernelIOMMU ON CACHE BOOL "" FORCE)
-        endif()
+      set(KernelMaxNumNodes 4 CACHE STRING "" FORCE)
     endif()
+  else()
+    set(KernelMaxNumNodes 1 CACHE STRING "" FORCE)
+  endif()
 
-    # sel4test specific config settings.
-
-    if(SIMULATION)
-        set(Sel4testSimulation ON CACHE BOOL "" FORCE)
-        set(Sel4testHaveCache OFF CACHE BOOL "" FORCE)
-    else()
-        set(Sel4testSimulation OFF CACHE BOOL "" FORCE)
-        set(Sel4testHaveCache ON CACHE BOOL "" FORCE)
-    endif()
-
-    # Test hardware debug API on non-simulation debug configs.
-    # IA32 simulation does support it, so allow there.
-    if(DEBUG AND ((NOT SIMULATION) OR KernelSel4ArchIA32) AND NOT KernelHardwareDebugAPIUnsupported)
-        set(HardwareDebugAPI ON CACHE BOOL "" FORCE)
-    else()
-        set(HardwareDebugAPI OFF CACHE BOOL "" FORCE)
-    endif()
-
-    ApplyCommonReleaseVerificationSettings(${RELEASE} ${VERIFICATION})
-
-    if(BAMBOO)
-        set(LibSel4TestPrintXML ON CACHE BOOL "" FORCE)
-    else()
-        set(LibSel4TestPrintXML OFF CACHE BOOL "" FORCE)
-    endif()
-
-    if(DOMAINS)
-        set(KernelNumDomains 4 CACHE STRING "" FORCE)
-    else()
-        set(KernelNumDomains 1 CACHE STRING "" FORCE)
-    endif()
-
-    if(SMP)
-        if(NUM_NODES MATCHES "^[0-9]+$")
-            set(KernelMaxNumNodes ${NUM_NODES} CACHE STRING "" FORCE)
-        else()
-            set(KernelMaxNumNodes 4 CACHE STRING "" FORCE)
-        endif()
-    else()
-        set(KernelMaxNumNodes 1 CACHE STRING "" FORCE)
-    endif()
-
-    if(MCS)
-        set(KernelIsMCS ON CACHE BOOL "" FORCE)
-    else()
-        set(KernelIsMCS OFF CACHE BOOL "" FORCE)
-    endif()
+  if(MCS)
+    set(KernelIsMCS ON CACHE BOOL "" FORCE)
+  else()
+    set(KernelIsMCS OFF CACHE BOOL "" FORCE)
+  endif()
 
 endif()


### PR DESCRIPTION
Make release builds equal to verification builds and mirror the seL4 kernel default: leave HardwareDebugAPI to default OFF on release builds.

To make sure the hardware debug API is still tested, we keep it on for overall DEBUG builds where supported.

Kernel debug builds and the hardware debug API are two separate things, but adding another test dimension to debug/release/verification would increase the numbers of tests too much.