### PR TITLE
Disable MCS scheduler+interrupt tests under SIM

### DIFF
--- a/apps/sel4test-tests/src/tests/interrupt.c
+++ b/apps/sel4test-tests/src/tests/interrupt.c
@@ -120,7 +120,9 @@ static int test_interrupt_notification_and_tcb_sc(env_t env)
 }
 DEFINE_TEST(INTERRUPT0003,
             "Test interrupts with scheduling context donation from notification object and without (two clients)",
-            test_interrupt_notification_and_tcb_sc, config_set(CONFIG_HAVE_TIMER) &&config_set(CONFIG_KERNEL_MCS));
+            test_interrupt_notification_and_tcb_sc, config_set(CONFIG_HAVE_TIMER) &&config_set(CONFIG_KERNEL_MCS)
+            /* This test is flakey under QEMU simulation: see https://github.com/seL4/ci-actions/pull/233 */
+            && !config_set(CONFIG_SIMULATION));
 
 /* test that if niether the thread or notification object have a scheduling context, nothing happens */
 static int test_interrupt_no_sc(env_t env)
@@ -212,7 +214,9 @@ int test_interrupt_notification_sc_two_clients(env_t env)
     return sel4test_get_result();
 }
 DEFINE_TEST(INTERRUPT0005, "Test the same scheduling context cannot be loaned to different threads",
-            test_interrupt_notification_sc_two_clients, config_set(CONFIG_HAVE_TIMER) &&config_set(CONFIG_KERNEL_MCS));
+            test_interrupt_notification_sc_two_clients, config_set(CONFIG_HAVE_TIMER) &&config_set(CONFIG_KERNEL_MCS)
+            /* This test is flakey under QEMU simulation: see https://github.com/seL4/ci-actions/pull/233 */
+            && !config_set(CONFIG_SIMULATION));
 
 /* test deleting the scheduling context stops the notification from donating it */
 static int test_interrupt_delete_sc(env_t env)

--- a/apps/sel4test-tests/src/tests/scheduler.c
+++ b/apps/sel4test-tests/src/tests/scheduler.c
@@ -1027,7 +1027,9 @@ int test_scheduler_accuracy(env_t env)
     return sel4test_get_result();
 }
 DEFINE_TEST(SCHED0011, "Test scheduler accuracy",
-            test_scheduler_accuracy, config_set(CONFIG_KERNEL_MCS) &&config_set(CONFIG_HAVE_TIMER))
+            test_scheduler_accuracy, config_set(CONFIG_KERNEL_MCS) &&config_set(CONFIG_HAVE_TIMER)
+            /* This test is flakey under QEMU simulation: see https://github.com/seL4/ci-actions/pull/233 */
+            && !config_set(CONFIG_SIMULATION))
 
 /* used by sched0012, 0013, 0014 */
 static void
@@ -1152,7 +1154,9 @@ int test_ordering_periodic_threads(env_t env)
     return sel4test_get_result();
 }
 DEFINE_TEST(SCHED0014, "Test periodic thread ordering", test_ordering_periodic_threads,
-            config_set(CONFIG_KERNEL_MCS) &&config_set(CONFIG_HAVE_TIMER))
+            config_set(CONFIG_KERNEL_MCS) &&config_set(CONFIG_HAVE_TIMER)
+            /* This test is flakey under QEMU simulation: see https://github.com/seL4/ci-actions/pull/233 */
+            && !config_set(CONFIG_SIMULATION))
 
 static void
 sched0015_helper(int id, env_t env, volatile unsigned long long *counters)


### PR DESCRIPTION
These tests fail for me in various ways when running under QEMU simulator. They fail ocassionally but also when interfered with using `stress -n 64` on an 8-core machine they tend to regularly fail; our GitHub runners are virtual machines and are often able to fail similarly.

QEMU is not cycle-accurate, so we expect some deviation with timing-related tests here. However, we should investigate more thoroughly, this is a basic fix so that we can build MCS in our basic pre-merge simulation tests on seL4 PRs.

Related: https://github.com/seL4/ci-actions/pull/233