### PR TITLE
Include gen_config for CONFIG_SIMULATION

### DIFF
--- a/apps/sel4test-tests/src/tests/faults.c
+++ b/apps/sel4test-tests/src/tests/faults.c
@@ -5,6 +5,8 @@
  */
 
 #include <autoconf.h>
+#include <sel4test-driver/gen_config.h>
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This wasn't included, so it wasn't defined, so it was always false and so this test always ran.

(Added in https://github.com/seL4/sel4test/pull/146 without the header)